### PR TITLE
fix: set stdout in exec when not tty is available

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -109,7 +109,11 @@ func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	}
 
 	c.SetStdin(p.input)
-	c.SetStdout(p.output.TTY())
+	if p.output.TTY() != nil {
+		c.SetStdout(p.output.TTY())
+	} else {
+		c.SetStdout(p.output)
+	}
 	c.SetStderr(os.Stderr)
 
 	// Execute system command.


### PR DESCRIPTION
Currently, Exec will force the stdout to the TTY. However, if there's no TTY available, the stdout should be just the program stdout.